### PR TITLE
Adds support for Terraform version `1.2.x`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ TF_MODULES  = $(sort $(dir $(wildcard $(CURRENT_DIR)modules/*/)))
 # -------------------------------------------------------------------------------------------------
 # Container versions
 # -------------------------------------------------------------------------------------------------
-TF_VERSION      = light
-TFDOCS_VERSION  = 0.8.1-0.18
-FL_VERSION      = 0.2
+TF_VERSION      = 1.2.8
+TFDOCS_VERSION  = 0.9.1-0.31
+FL_VERSION      = 0.4
 JL_VERSION      = latest-0.4
 
 
@@ -79,12 +79,9 @@ test: _pull-tf
 		echo "------------------------------------------------------------"; \
 		if docker run $$(tty -s && echo "-it" || echo) --rm -v "$(CURRENT_DIR):/t" --workdir "$${DOCKER_PATH}" hashicorp/terraform:$(TF_VERSION) \
 			init \
-				-verify-plugins=true \
-				-lock=false \
 				-upgrade=true \
 				-reconfigure \
 				-input=false \
-				-get-plugins=true \
 				-get=true \
 				.; then \
 			echo "OK"; \

--- a/README.md
+++ b/README.md
@@ -22,23 +22,30 @@ You can read more about how Terraform handles this [here][5].
 
 Obviously, all the [supported authentication][6] methods can also be used.
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 1.2 |
+| aws | ~> 4.27.0 |
+
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | ~> 4.27.0 |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | aws\_account\_id\_hub | AWS account number containing the TGW hub | `string` | n/a | yes |
-| aws\_account\_id\_satellite | List of AWS account numbers representing the satellites of the TGW | `list` | n/a | yes |
-| description | Description of the Transit Gateway | `string` | n/a | yes |
+| aws\_account\_id\_satellite | List of AWS account numbers representing the satellites of the TGW | `list(any)` | n/a | yes |
 | name | Name to be used on all the resources as identifier | `string` | n/a | yes |
 | role\_to\_assume\_hub | IAM role name to assume in the AWS account containing the TGW hub (eg. ASSUME-ROLE-HUB) | `string` | n/a | yes |
 | default\_route\_table\_association | Boolean flag for toggling the default route table association | `string` | `"disable"` | no |
 | default\_route\_table\_propagation | Boolean flag for toggling the propagation of routes in the default route table | `string` | `"disable"` | no |
+| description | Description of the Transit Gateway | `string` | `null` | no |
 | tags | A map of tags to add to all resources | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/examples/hub-and-satellite/README.md
+++ b/examples/hub-and-satellite/README.md
@@ -1,4 +1,8 @@
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 No provider.
@@ -6,7 +10,7 @@ No provider.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | aws\_account\_id\_hub | AWS account number containing the TGW hub | `string` | n/a | yes |
 | aws\_account\_id\_satellite | List of AWS account numbers representing the satellites of the TGW | `list` | n/a | yes |
 | aws\_login\_profile | Name of the AWS login profile as seen under ~/.aws/config used for assuming cross-account roles | `any` | n/a | yes |

--- a/examples/hub/README.md
+++ b/examples/hub/README.md
@@ -1,4 +1,8 @@
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
 ## Providers
 
 No provider.
@@ -6,7 +10,7 @@ No provider.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:-----:|
+|------|-------------|------|---------|:--------:|
 | aws\_account\_id\_hub | AWS account number containing the TGW hub | `string` | n/a | yes |
 | aws\_account\_id\_satellite | List of AWS account numbers representing the satellites of the TGW | `list` | n/a | yes |
 | aws\_login\_profile | Name of the AWS login profile as seen under ~/.aws/config used for assuming cross-account roles | `any` | n/a | yes |

--- a/versions.tf
+++ b/versions.tf
@@ -1,8 +1,9 @@
 terraform {
+  required_version = ">= 1.2"
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = "~> 4.27.0"
     }
   }
-  required_version = ">= 0.13"
 }


### PR DESCRIPTION
# Adds support for Terraform version `1.2.x`

## Description

Upcoming release tag: `v2.1.0`

## Testing Instructions

```shell
$ make test
```

## How to roll out

N/A

## Notes

N/A

## Demo

N/A