### PR TITLE
Adds support for Terraform v1.5.x

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 1.2"
+  required_version = "~> 1.5.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.30"
+      version = "~> 5.31"
     }
   }
 }


### PR DESCRIPTION
# Adds support for Terraform v1.5.x

## Description

Upcoming release tag: `v3.0.0`

## Testing Instructions

N/A

## How to roll out

N/A

## Notes

N/A

## Demo

N/A
